### PR TITLE
adding missing global flag

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -16,6 +16,7 @@ images_dict = {}
 
 
 def load_pdf_page(filepath, page_number):
+    global images_dict
     pdf_image_key = filepath + "[{0}]".format(page_number)
     if pdf_image_key in images_dict:
         image = images_dict[pdf_image_key]


### PR DESCRIPTION
Keep the ``load_pdf_page`` function from unnecessarily loading the same page multiple times. I'm not sure if dictionary object can get away with not declaring a global flag, but I'd like to add it just to make sure. 