### PR TITLE
t1_22 small fix

### DIFF
--- a/tutor/test_t1_22_ViewClassPerformance.py
+++ b/tutor/test_t1_22_ViewClassPerformance.py
@@ -213,9 +213,8 @@ class TestViewClassPerformance(unittest.TestCase):
                 (By.LINK_TEXT, 'Dashboard')
             )
         ).click()
-
-        assert('calendar' in self.teacher.current_url()), \
-            'Not viewing the calendar dashboard'
+        self.teacher.find(
+            By.XPATH, '//div[contains(@class,"calendar-container")]')
 
         self.ps.test_updates['passed'] = True
 


### PR DESCRIPTION
fixed case with calendar in url

case about looking at class with zero answers doesn't pass anymore
It used to make a new period and then look at the forecast for that period. But new periods cannot be created anymore. To ensure a class/period with zero answers should it create a whole new class/"teach again" ?
